### PR TITLE
Fix bug where secure storage read would throw null error

### DIFF
--- a/lib/core/api/database/repository/secure_storage_repository.dart
+++ b/lib/core/api/database/repository/secure_storage_repository.dart
@@ -8,7 +8,11 @@ class SecureStorageRepository implements ISecureStorage {
 
   @override
   Future<String?> getRefreshToken() async {
-    return await secureStorage.read(key: SecureStorageKeys.refreshToken, aOptions: aOptions);
+    try {
+      return await secureStorage.read(key: SecureStorageKeys.refreshToken, aOptions: aOptions);
+    } catch (e) {
+      clear();
+    }
   }
 
   @override

--- a/lib/core/ui/cubit/auth_cubit.dart
+++ b/lib/core/ui/cubit/auth_cubit.dart
@@ -29,7 +29,6 @@ class AuthCubit extends Cubit<AuthState> {
     login();
   }
   final _userRepo = getIt<UserActionRepository>();
-  final _secureStorage = getIt<SecureStorageRepository>();
   final _focusNodePassword = FocusNode();
   final _focusNodeUsername = FocusNode();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   shared_preferences: ^2.0.15
   freezed_annotation: ^2.0.3
   json_annotation: ^4.5.0
-  flutter_secure_storage: ^5.0.2
+  flutter_secure_storage: ^6.0.0
   awesome_notifications: ^0.7.3
   url_launcher: ^6.1.5
   flutter_colorpicker: ^1.0.3


### PR DESCRIPTION
An update issue between flutter and secure storage made old stored data break the app. If there's any error in reading the refresh token, the app will now delete it from secure storage